### PR TITLE
Fix empty result issue and scanner closing issue

### DIFF
--- a/src/Scanner.java
+++ b/src/Scanner.java
@@ -1492,6 +1492,7 @@ public final class Scanner {
       final ScanRequest req = ScanRequest.newBuilder()
         .setScannerId(scanner_id)
         .setCloseScanner(true)
+        .setNumberOfRows(0)
         .build();
       return toChannelBuffer(SCAN, req);
     }

--- a/src/Scanner.java
+++ b/src/Scanner.java
@@ -1143,13 +1143,13 @@ public final class Scanner {
         for (int j = 0; j < nkvs; j++) {
           final int kv_length = buf.readInt();
           kv = KeyValue.fromBuffer(buf, kv);
+          row.add(kv);
           if (filteringCallback != null) {
               try {
                   shouldKeep = shouldKeep || HBaseRpc.keep(kv, filteringCallback);
               } catch (Exception e) {
                   throw new NonRecoverableException("HBaseRpc.keep failed:", e);
               }
-              row.add(kv);
           } else {
               shouldKeep = true;
           }


### PR DESCRIPTION
1. fix an issue of returning empty result when filterCallback is null
2. cherry-pick a commit from OpenTSDB to fix closing scanner issue due to hbase version incompatibility 

@jasonculverhouse @lzheng 